### PR TITLE
Update netconf-1.py

### DIFF
--- a/Python/Networking/IOS-XE/netconf-1.py
+++ b/Python/Networking/IOS-XE/netconf-1.py
@@ -1,8 +1,9 @@
 from ncclient import manager
 
-
-router = {"host": "ios-xe-mgmt-latest.cisco.com", "port": "10000",
+# updated host address and port
+router = {""host": "sandbox-iosxe-latest-1.cisco.com", "port": "830",
           "username": "developer", "password": "C1sco12345"}
 
-with manager.connect(host=router["host"], port=router["port"], username=router["username"], password=router["password"], hostkey_verify=False) as m:
+# added new arguments to eliminate 'ncclient.transport.errors.AuthenticationError: SSHException('No existing session')' error.
+with manager.connect(host=router["host"], port=router["port"], username=router["username"], password=router["password"], hostkey_verify=False, allow_agent=False, look_for_keys=False) as m:
     m.close_session()


### PR DESCRIPTION
- updated 'host' and 'port' with info of a currently running DevNet Sandbox
- added new arguments to eliminate 'ncclient.transport.errors.AuthenticationError: SSHException('No existing session')' error.