### PR TITLE
Resolved issue with https://dcloud-dna-center-inst-rtp.cisco.com

### DIFF
--- a/Python/Networking/DNA/auth.py
+++ b/Python/Networking/DNA/auth.py
@@ -1,14 +1,9 @@
 import requests
 import json
 
-base_url = "https://dcloud-dna-center-inst-rtp.cisco.com/dna/"
-auth_endpoint = "system/api/v1/auth/token"
+auth_response = requests.post('https://sandboxdnac.cisco.com/dna/system/api/v1/auth/token', headers={'Authorization': 'Basic ZGV2bmV0dXNlcjpDaXNjbzEyMyE='}).json()
 
-user = 'demo'
-password = 'demo1234!'
-
-auth_response = requests.post(
-    url=f"{base_url}{auth_endpoint}", auth=(user, password)).json()
+print (auth_response)
 
 token = auth_response['Token']
 


### PR DESCRIPTION
Hey Knox,

Here is my attempt to fix an issue with the code from the Cisco CCNP Automating Enterprise Solutions (300-435 ENAUTO) - 88. Getting Authenticated video. Guessing Cisco has updated the https://dcloud-dna-center-inst-rtp.cisco.com instance and inadvertently broke the code.

Changes are to use https://sandboxdnac.cisco.com always-on-instance and to use an authorization header base64 encoded as per Cisco guidelines. 

Hope this code contribute helps out the rest of the Cisco learning community. 

Kind regards
Tyler